### PR TITLE
context: Declare executeState as a volatile variable

### DIFF
--- a/src/main/java/com/haeungun/mocketl/ApplicationContext.java
+++ b/src/main/java/com/haeungun/mocketl/ApplicationContext.java
@@ -5,7 +5,7 @@ import com.haeungun.mocketl.enums.ExecuteState;
 public class ApplicationContext {
 
     private final ApplicationConfig config;
-    private ExecuteState executeState;
+    private volatile ExecuteState executeState;
 
     public ApplicationContext() {
         this.config = new ApplicationConfig();


### PR DESCRIPTION
By declaring `executeState` as volatile, it is guaranteed to always read the latest value in memory.

Fix: #3 